### PR TITLE
Consolidate all deployment branches into a single branch

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -25,7 +25,7 @@ steps:
       - export NIX_PATH=nixpkgs=$(nix eval --raw "((import nix/sources.nix).nixpkgs.outPath)")
       - cd scripts
       - nix-build -E "with import <nixpkgs> { }; haskellPackages.callPackage ./deploy { }"
-      - ./result/bin/deploy --repo "ssh://git@github.com/stakerdao/blend-app" --ref "${REF-balsoft/nix}" Blend_Demo System
+      - ./result/bin/deploy --repo "ssh://git@github.com/stakerdao/blend-app" --ref "${REF-demo}" Blend_Demo System
     branches:
       - blnd-demo
     agents:

--- a/modules/services/blend-tender.nix
+++ b/modules/services/blend-tender.nix
@@ -15,7 +15,7 @@ let
     };
     min-severity = mkOption {
       type = types.enum [ "Debug" "Info" "Warning" "Error" ];
-      default = "Warning";
+      default = "Debug";
     };
   };
 
@@ -39,7 +39,7 @@ in {
         };
         secure_cookies = mkOption {
           type = types.bool;
-          default = false;
+          default = true;
         };
         frontend_addr = mkOption {
           type = types.string;
@@ -95,8 +95,13 @@ in {
           type = types.str;
           default = "${config.networking.hostName}.${config.networking.domain}";
         };
+        timeout_ms = mkOption {
+          type = types.int;
+          default = 5000;
+          description = "Timeout for all SMTP operations (in milliseconds)";
+        };
       };
-      web3 = {
+      eth = {
         provider = mkOption {
           type = types.str;
           default = "<unset>";
@@ -104,6 +109,11 @@ in {
         blnd_address = mkOption {
           type = types.str;
           default = "<unset>";
+        };
+        fetcher_timeout_sec = mkOption {
+          type = types.int;
+          default = 5;
+          description = "Timeout for EthFetcher (in seconds)";
         };
       };
     };
@@ -135,9 +145,9 @@ in {
           logging: "$SMTP_LOGIN"
           password: "$SMTP_PASSWORD"
           sender: "$SMTP_SENDER"
-        web3:
-          provider: "$WEB3_PROVIDER"
-          blnd_address: "$WEB3_BLND_ADDRESS"
+        eth:
+          provider: "$ETH_PROVIDER"
+          blnd_address: "$ETH_BLND_ADDRESS"
         EOF
       '';
     };
@@ -160,10 +170,10 @@ in {
       package = pkgs.postgresql_12;
 
       ensureDatabases = [ "blnd" ];
-      ensureUsers = [{
-        name = "blend-tender";
+      ensureUsers = map (name: {
+        inherit name;
         ensurePermissions = { "DATABASE \"blnd\"" = "ALL"; };
-      }];
+      }) [ "blend-tender" "gpevnev" "sashasashasasha151" "georgeee" ];
     };
 
     services.nginx = {

--- a/nodes/common.nix
+++ b/nodes/common.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, config, ... }:
 let
-  wheel = [ "chris" "kirelagin" "yorick" "balsoft" "sashasashasasha151" "zhenya" ];
+  wheel = [ "chris" "kirelagin" "yorick" "balsoft" "sashasashasasha151" "zhenya" "gpevnev" ];
   expandUser = _name: keys: {
     extraGroups =
       (lib.optionals (builtins.elem _name wheel) [ "wheel" ])


### PR DESCRIPTION
Git histories for deployment branches (`production`, `staging` and `blnd-demo`) have diverged, this PR merges all differences into a single branch (by merging `blnd-demo` into `master`).

Diffs between this PR and deployment branches:
https://github.com/serokell/stakerdao-infra/compare/production..zhenya/merge-master
https://github.com/serokell/stakerdao-infra/compare/staging..zhenya/merge-master
https://github.com/serokell/stakerdao-infra/compare/blnd-demo..zhenya/merge-master

So for `production` and `staging` it
1. Adds blend-demo instance config, which won't affect the agora instances
2. Moves `vault-secrets`, `networking.domain` and `security.acme` configs from `agora.nix` to `common.nix`
3. Adds gpevnev to wheel (https://github.com/serokell/stakerdao-infra/pull/18). @balsoft would it be more proper to only add gpevnev to wheel for `blnd-demo` instance?
4. Adds zhenya to wheel (https://github.com/serokell/stakerdao-infra/pull/16)

And for `blnd-demo` it justs adds zhenya to wheel.