### PR TITLE
[OPS-1138] Hide prometheus node exporter metrics behind wireguard

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -3,6 +3,7 @@
   imports = [
     inputs.serokell-nix.nixosModules.common
     inputs.serokell-nix.nixosModules.serokell-users
+    inputs.serokell-nix.nixosModules.wireguard-monitoring
     inputs.vault-secrets.nixosModules.vault-secrets
 
     inputs.serokell-nix.nixosModules.ec2
@@ -15,9 +16,6 @@
     vaultPrefix = "kv/sys/stakerdao/${config.networking.hostName}";
     approlePrefix = "stakerdao-${config.networking.hostName}";
   };
-
-  networking.firewall.allowedTCPPorts =
-    [ config.services.prometheus.exporters.node.port ];
 
   services.nginx = {
     # SDAO-191

--- a/flake.lock
+++ b/flake.lock
@@ -795,11 +795,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1612858101,
-        "narHash": "sha256-XJ8WVB+z3LxUTdan8K+kiL/Frhdu9JoUeLnBm7zYmmQ=",
+        "lastModified": 1617871354,
+        "narHash": "sha256-3sCuJbCke12dnvude2nxk2isrGPdvZT3uM9A/fcb1Hs=",
         "owner": "serokell",
         "repo": "nixpkgs",
-        "rev": "11db098dcba5846805c42d7429854cd0af58645a",
+        "rev": "fd8bfa0b61ac80181e8e39abde9004e75dc7045e",
         "type": "github"
       },
       "original": {
@@ -1010,11 +1010,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1615464380,
-        "narHash": "sha256-E9jCkjw/FBravLGKMx4n9ebwTdBIBGe1WGrzqt4UpoU=",
+        "lastModified": 1619096503,
+        "narHash": "sha256-eVWfdjBLjThw8iv/qeZCB/wM/NtpSUrRdcosXDezek0=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "276198e6504e660f559b7f1c24f0e03c4b8c435b",
+        "rev": "c3d9c4778066abcf1246a6a07c982bee5d026b91",
         "type": "github"
       },
       "original": {

--- a/servers/blend-demo/default.nix
+++ b/servers/blend-demo/default.nix
@@ -2,4 +2,5 @@
   imports = [ ../../profiles/blend-tender.nix ];
 
   networking.hostName = "blend";
+  wireguard-ip-address = "172.21.0.26";
 }

--- a/servers/bridge-testing/default.nix
+++ b/servers/bridge-testing/default.nix
@@ -1,4 +1,5 @@
 {
   imports = [ ../../profiles/bridge.nix ];
   networking.hostName = "bridge";
+  wireguard-ip-address = "172.21.0.27";
 }

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -43,8 +43,8 @@ resource "aws_instance" "blend_demo" {
   vpc_security_group_ids = [
     aws_security_group.egress_all.id,
     aws_security_group.http.id,
-    aws_security_group.prometheus_exporter_node.id,
     aws_security_group.ssh.id,
+    aws_security_group.wireguard.id,
   ]
 
   # Instance parameters
@@ -76,8 +76,8 @@ resource "aws_instance" "bridge_testing" {
   vpc_security_group_ids = [
     aws_security_group.egress_all.id,
     aws_security_group.http.id,
-    aws_security_group.prometheus_exporter_node.id,
     aws_security_group.ssh.id,
+    aws_security_group.wireguard.id,
   ]
 
   # Instance parameters
@@ -109,21 +109,6 @@ resource "aws_security_group" "egress_all" {
     from_port   = 0
     to_port     = 0
     protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    ipv6_cidr_blocks = ["::/0"]
-  }
-}
-
-# Allow traffic for the tezos node
-resource "aws_security_group" "prometheus_exporter_node" {
-  name = "prometheus_exporter_node"
-  description = "Allow Prometheus Node Exporter data scraping"
-  vpc_id = module.vpc.vpc_id
-
-  ingress {
-    from_port = 9100
-    to_port = 9100
-    protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
@@ -171,6 +156,21 @@ resource "aws_security_group" "http" {
     to_port = 443
     protocol = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+}
+
+# Allow wireguard traffic
+resource "aws_security_group" "wireguard" {
+  name = "wireguard"
+  description = "Allow inbound and outbound traffic for wireguard"
+  vpc_id = module.vpc.vpc_id
+
+  ingress {
+    from_port        = 51820
+    to_port          = 51820
+    protocol         = "udp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 }


### PR DESCRIPTION
Export prometheus node exporter metrics over wireguard, like we do for newer servers. See https://issues.serokell.io/issue/OPS-1138.