### PR TITLE
[OPS-1192] Bump vault-secrets to fix secret escaping

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -365,6 +365,22 @@
         "type": "github"
       }
     },
+    "flake-compat_9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603796912,
+        "narHash": "sha256-6ayqpH/4XiEXylNdWI3AghubqS6XuiPg3Y60jY8RTo4=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "19576c2aea7f074ff0da818b21a8b0950ff6ec86",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "locked": {
         "lastModified": 1605370193,
@@ -396,6 +412,21 @@
       }
     },
     "flake-utils_3": {
+      "locked": {
+        "lastModified": 1605370193,
+        "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5021eac20303a61fafe17224c087f5519baed54d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_4": {
       "locked": {
         "lastModified": 1605370193,
         "narHash": "sha256-YyMTf3URDL/otKdKgtoMChu4vfVL3vCMkRqpGifhUn0=",
@@ -555,6 +586,22 @@
       }
     },
     "lowdown-src_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1598695561,
+        "narHash": "sha256-gyH/5j+h/nWw0W8AcR2WKvNBUsiQ7QuxqSJNXAwV+8E=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "1705b4a26fbf065d9574dce47a94e8c7c79e052f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
+    "lowdown-src_3": {
       "flake": false,
       "locked": {
         "lastModified": 1598695561,
@@ -779,6 +826,25 @@
         "type": "github"
       }
     },
+    "nix-unstable_3": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_3",
+        "nixpkgs": "nixpkgs_15"
+      },
+      "locked": {
+        "lastModified": 1605815976,
+        "narHash": "sha256-ApWh7Lz6x75scuL8DI7mR2L9NjSSZ6clbds5k9M7NN4=",
+        "owner": "nixos",
+        "repo": "nix",
+        "rev": "4dcb183af31d5cb33b6ef8e581e77d1c892a58b9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1608557166,
@@ -866,6 +932,36 @@
         "id": "nixpkgs",
         "ref": "nixos-20.09-small",
         "type": "indirect"
+      }
+    },
+    "nixpkgs_15": {
+      "locked": {
+        "lastModified": 1602702596,
+        "narHash": "sha256-fqJ4UgOb4ZUnCDIapDb4gCrtAah5Rnr2/At3IzMitig=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ad0d20345219790533ebe06571f82ed6b034db31",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-20.09-small",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_16": {
+      "locked": {
+        "lastModified": 1605865875,
+        "narHash": "sha256-YCFX86nAoGhIu47B/hdd/KFeBQt/kpjm6fcPHgcpQ5I=",
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "rev": "ee802725a8bbb93cdfaaeff6e94166f2a00804f1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "serokell",
+        "repo": "nixpkgs",
+        "type": "github"
       }
     },
     "nixpkgs_2": {
@@ -1212,12 +1308,18 @@
       }
     },
     "vault-secrets": {
+      "inputs": {
+        "flake-compat": "flake-compat_9",
+        "flake-utils": "flake-utils_4",
+        "nix-unstable": "nix-unstable_3",
+        "nixpkgs": "nixpkgs_16"
+      },
       "locked": {
-        "lastModified": 1615996922,
-        "narHash": "sha256-f0fS/ak6pNzhIesy9e8TZSv/oEfbbmOGhKvKBQCkR/4=",
+        "lastModified": 1619415603,
+        "narHash": "sha256-CkKmzwSAuRtYUzxbwz32V4bzhAXB8h6F3tJTkLCjg0w=",
         "owner": "serokell",
         "repo": "vault-secrets",
-        "rev": "f714d2a5dd4d2fc8955bab4a63fee440b3dd6b3a",
+        "rev": "0dfb5d38d23896c58b0df61bea9750b24e4ed8ed",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
@balsoft Can you deploy it? To test that there are no issues with the new vault-secrets version