### PR TITLE
[OPS-1230] Bump serokell.nix to fix NTP

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1106,11 +1106,11 @@
         "nixpkgs": "nixpkgs_10"
       },
       "locked": {
-        "lastModified": 1619096503,
-        "narHash": "sha256-eVWfdjBLjThw8iv/qeZCB/wM/NtpSUrRdcosXDezek0=",
+        "lastModified": 1621844655,
+        "narHash": "sha256-LlXyUc7tNNmnWS/W0zz0OVtpSgEu1zBxp0TBPxNokdg=",
         "owner": "serokell",
         "repo": "serokell.nix",
-        "rev": "c3d9c4778066abcf1246a6a07c982bee5d026b91",
+        "rev": "42b192ca488df6e0ae5f4e3abbe99e615b632e55",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
@balsoft can you deploy this please? At least so that we're sure it doesn't break anything. It applies https://github.com/serokell/serokell.nix/pull/42