### PR TITLE
[OPS-1236] Update users

### DIFF
--- a/common.nix
+++ b/common.nix
@@ -26,5 +26,5 @@
   };
 
   serokell-users.wheelUsers =
-    [ "gpevnev" "georgeee" "sashasashasasha151" ];
+    [ "gromak" "georgeee" "worm2fed" ];
 }

--- a/profiles/bridge.nix
+++ b/profiles/bridge.nix
@@ -39,7 +39,7 @@ in {
     ensureUsers = map (name: {
       inherit name;
       ensurePermissions = { "DATABASE \"${dbname}\"" = "ALL"; };
-    }) [ "gpevnev" "sashasashasasha151" "georgeee" ];
+    }) [ "gromak" "worm2fed" "georgeee" ];
   };
 
   services.bridge = {


### PR DESCRIPTION
Problem: `gpevnev` and `sashasashasasha151` are not working on
StakerDAO anymore. `gromak` and `worm2fed` replaced them.

Solution: change lists of users in 2 places.