### PR TITLE
[SDAO-410] Update Tezos endpoint to florencenet

### DIFF
--- a/profiles/bridge.nix
+++ b/profiles/bridge.nix
@@ -52,7 +52,7 @@ in {
       secretFile = "${config.vault-secrets.secrets.${service}}/environment";
       serviceName = service;
       config = {
-        chains.tezos.custom.endpoint = "http://edo.testnet.tezos.serokell.team:8732";
+        chains.tezos.custom.endpoint = "http://florence.testnet.tezos.serokell.team:8732";
       };
       inherit user;
     };


### PR DESCRIPTION
Problem: `chains.tezos.custom.endpoint` is set to old testnet
and bridge-web was recently updated to the latest one (florencenet).

Solution: update `endpoint` value to the florencenet endpoint.