### PR TITLE
Cleanup bridge.nix

### DIFF
--- a/profiles/bridge.nix
+++ b/profiles/bridge.nix
@@ -57,7 +57,6 @@ in {
       secretFile = "${config.vault-secrets.secrets.${service}}/environment";
       serviceName = service;
       config = {
-        chains.tezos.custom.endpoint = "http://florence.testnet.tezos.serokell.team:8732";
       };
       inherit user;
     };

--- a/profiles/bridge.nix
+++ b/profiles/bridge.nix
@@ -39,7 +39,7 @@ in {
     ensureUsers = map (name: {
       inherit name;
       ensurePermissions = { "DATABASE \"${dbname}\"" = "ALL"; };
-    }) [ "gromak" "worm2fed" "georgeee" ];
+    }) [ "gromak" ];
   };
 
   systemd.services.bridge.serviceConfig = {


### PR DESCRIPTION
See commits, the related issue is https://issues.serokell.io/issue/SDAO-466

@balsoft 
1. I don't know whether defining `config = {}` is nice or I should remove it completely.
2. Am I right that by default https://github.com/StakerDAO/bridge-web/blob/master/backend/server/config.yaml is used and that `config` in `bridge.nix` is supposed to override some fields in it?
3. After this PR is approved and merged I'll need you to deploy it.